### PR TITLE
Fix broken autoloading due to composer.json discrepancy

### DIFF
--- a/DeviantartExtendSocialite.php
+++ b/DeviantartExtendSocialite.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SocialiteProviders\deviantART;
+namespace SocialiteProviders\Deviantart;
 
 use SocialiteProviders\Manager\SocialiteWasCalled;
 


### PR DESCRIPTION
Due to the difference between the autoload namespace specified in `composer.json` and the actual namespace in the file that contains the class this repository currently breaks Composer commands after adding it to the `$listen[]` array of `app/Providers/EventServiceProvider.php` in a Laravel project.

```
$ composer update
Loading composer repositories with package information
Nothing to install or update
Generating optimized autoload files
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover

                                                                               
  [ReflectionException]                                                        
  Class \SocialiteProviders\Deviantart\DeviantartExtendSocialite does not exi  
  st                                                                           
                                                                               

Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1
```

I changed the namespace in the php file instead of copying the one in the file to the `composer.json` because [this page](http://socialiteproviders.github.io/providers/deviantart/) suggests the use of that form over the one found in the file.

While this should work for now, I would highly suggest that eventually both this repository and the providers site be updated with the [new stylization](https://spyed.deviantart.com/journal/Boldly-Facing-The-Future-498282387) of the name: DeviantArt.